### PR TITLE
🎈 perf(request): 重构请求模块

### DIFF
--- a/src/lib/hamibotApi.ts
+++ b/src/lib/hamibotApi.ts
@@ -1,20 +1,20 @@
-import * as FormData from 'form-data';
-import { Uri, workspace } from 'vscode';
-import { basename, extname } from 'path';
+import * as FormData from "form-data";
+import { Uri, workspace } from "vscode";
+import { basename, extname } from "path";
 
-import * as request from "./request";
-import { RobotInfo } from './projectConfig';
-import { validRobotId, validScriptId } from './valid';
+import { Request } from "./request";
+import { RobotInfo } from "./projectConfig";
+import { validRobotId, validScriptId } from "./valid";
 
 export class Robot {
-    private constructor() { };
+    private constructor() {}
 
     /**
      * @description: 获取机器人列表。
      * @return {Promise<RobotList>} 机器人列表。
      */
     static async getRobotList(): Promise<RobotList> {
-        return request.get<RobotList>('/v1/robots');
+        return Request.get<RobotList>("/v1/robots");
     }
 
     /**
@@ -25,7 +25,7 @@ export class Robot {
     static async getRobotById(robotId: string): Promise<RobotItem> {
         // 校验机器人 ID 格式
         validRobotId(robotId);
-        return request.get<RobotItem>(`/v1/robots/${robotId}`);
+        return Request.get<RobotItem>(`/v1/robots/${robotId}`);
     }
 
     /**
@@ -35,7 +35,7 @@ export class Robot {
     static async stopRobotById(robotId: string): Promise<void> {
         // 校验机器人 ID 格式
         validRobotId(robotId);
-        await request.put(`/v1/robots/${robotId}/stop`);
+        await Request.put(`/v1/robots/${robotId}/stop`);
     }
 
     /**
@@ -48,7 +48,7 @@ export class Robot {
     static async sendMessage(robotId: string, msg: PostMessage): Promise<void> {
         // 校验机器人 ID 格式
         validRobotId(robotId);
-        await request.post(`/v1/robots/${robotId}/messages`, msg);
+        await Request.post(`/v1/robots/${robotId}/messages`, msg);
     }
 
     /**
@@ -59,7 +59,7 @@ export class Robot {
     static async rename(robotId: string, newName: string): Promise<void> {
         // 校验机器人 ID 格式
         validRobotId(robotId);
-        await request.put(`/v1/robots/${robotId}`, { name: newName });
+        await Request.put(`/v1/robots/${robotId}`, { name: newName });
     }
 }
 
@@ -109,14 +109,14 @@ interface PostMessage {
 }
 
 export class Script {
-    private constructor() { };
+    private constructor() {}
 
     /**
      * @description: 获取正在开发中的脚本列表。
      * @return {Promise<ScriptList>} 开发中的脚本列表。
      */
     static async getScriptList(): Promise<ScriptList> {
-        return request.get<ScriptList>('/v1/devscripts');
+        return Request.get<ScriptList>("/v1/devscripts");
     }
 
     /**
@@ -127,7 +127,7 @@ export class Script {
     static async getScriptById(scriptId: string): Promise<ScriptItem> {
         // 校验脚本 ID 格式
         validScriptId(scriptId);
-        return request.get<ScriptItem>(`/v1/devscripts/${scriptId}`);
+        return Request.get<ScriptItem>(`/v1/devscripts/${scriptId}`);
     }
 
     /**
@@ -136,7 +136,11 @@ export class Script {
      * @param {RobotInfo} robots 机器人标记。
      * @param {object} scriptConfig 运行时加载的脚本配置。
      */
-    static async runScript(scriptId: string, robots: RobotInfo[], scriptConfig?: object): Promise<void> {
+    static async runScript(
+        scriptId: string,
+        robots: RobotInfo[],
+        scriptConfig?: object
+    ): Promise<void> {
         // 校验脚本 ID 格式
         validScriptId(scriptId);
 
@@ -149,7 +153,7 @@ export class Script {
             data.vars = scriptConfig;
         }
 
-        await request.post(`/v1/devscripts/${scriptId}/run`, data);
+        await Request.post(`/v1/devscripts/${scriptId}/run`, data);
     }
 
     /**
@@ -157,14 +161,17 @@ export class Script {
      * @param {string} scriptId 脚本 ID 。
      * @param {RobotInfo} robots 机器人标记。
      */
-    static async stopScript(scriptId: string, robots: RobotInfo[]): Promise<void> {
+    static async stopScript(
+        scriptId: string,
+        robots: RobotInfo[]
+    ): Promise<void> {
         // 校验脚本 ID 格式
         validScriptId(scriptId);
 
         // 校验机器人 ID 格式
         robots.forEach((value) => validRobotId(value._id));
 
-        await request.del(`/v1/devscripts/${scriptId}/run`, { robots: robots });
+        await Request.del(`/v1/devscripts/${scriptId}/run`, { robots: robots });
     }
 
     /**
@@ -173,7 +180,7 @@ export class Script {
      * @return {Promise<ScriptItem>} 创建脚本的详细信息。
      */
     static async createNewScript(scriptName: string): Promise<ScriptItem> {
-        return request.post<ScriptItem>(`/v1/devscripts`, { name: scriptName });
+        return Request.post<ScriptItem>(`/v1/devscripts`, { name: scriptName });
     }
 
     /**
@@ -181,8 +188,11 @@ export class Script {
      * @param {string} scriptId 脚本 ID 。
      * @param {string} scriptName 新的脚本名称。
      */
-    static async changeScriptName(scriptId: string, scriptName: string): Promise<void> {
-        await request.put(`/v1/devscripts/${scriptId}`, { name: scriptName });
+    static async changeScriptName(
+        scriptId: string,
+        scriptName: string
+    ): Promise<void> {
+        await Request.put(`/v1/devscripts/${scriptId}`, { name: scriptName });
     }
 
     /**
@@ -190,7 +200,10 @@ export class Script {
      * @param {string} scriptId 脚本 ID 。
      * @param {Uri} filesUri 要上传的文件的 Uri 。
      */
-    static async uploadScript(scriptId: string, filesUri: Uri[]): Promise<void> {
+    static async uploadScript(
+        scriptId: string,
+        filesUri: Uri[]
+    ): Promise<void> {
         // 校验脚本 ID 格式
         validScriptId(scriptId);
 
@@ -199,16 +212,22 @@ export class Script {
         let jobs: Promise<any>[] = [];
         for (let i = 0; i < filesUri.length; i++) {
             let file = Script.transUriToFileInfo(filesUri[i]);
-            jobs.push((async () => {
-                fileData.append('file', await workspace.fs.readFile(file.uri), {
-                    contentType: file.fileType,
-                    filename: basename(file.uri.fsPath),
-                });
-            })());
+            jobs.push(
+                (async () => {
+                    fileData.append(
+                        "file",
+                        await workspace.fs.readFile(file.uri),
+                        {
+                            contentType: file.fileType,
+                            filename: basename(file.uri.fsPath),
+                        }
+                    );
+                })()
+            );
         }
         await Promise.all(jobs);
 
-        await request.put(`/v1/devscripts/${scriptId}/files`, fileData);
+        await Request.put(`/v1/devscripts/${scriptId}/files`, fileData);
     }
 
     /**
@@ -218,26 +237,28 @@ export class Script {
     static async deleteScript(scriptId: string): Promise<void> {
         // 校验脚本 ID 格式
         validScriptId(scriptId);
-        await request.del(`/v1/devscripts/${scriptId}`);
+        await Request.del(`/v1/devscripts/${scriptId}`);
     }
 
     private static transUriToFileInfo(fileUri: Uri): FileInfo {
         let fileType: string;
 
         switch (extname(fileUri.fsPath)) {
-            case '.json':
+            case ".json":
                 fileType = "application/json";
                 break;
-            case '.js':
+            case ".js":
                 fileType = "application/javascript";
                 break;
             default:
-                throw new Error(`不支持上传文件类型： ${extname(fileUri.fsPath)} 。`);
+                throw new Error(
+                    `不支持上传文件类型： ${extname(fileUri.fsPath)} 。`
+                );
         }
 
         return {
             uri: fileUri,
-            fileType: fileType
+            fileType: fileType,
         };
     }
 }

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -1,170 +1,164 @@
-import axios, {
-    AxiosRequestConfig,
-    RawAxiosRequestHeaders,
-    isAxiosError,
-} from "axios";
+import axios, { AxiosError, AxiosRequestConfig, isAxiosError } from "axios";
 import { commands, extensions, workspace } from "vscode";
 
 import { validToken } from "./valid";
 
-const BASE_URL = "https://api.hamibot.cn";
-const BACKUP_URL = "https://api.hamibot.com";
+export class Request {
+    public static readonly baseUrls: Set<string> = new Set([
+        "https://api.hamibot.cn",
+        "https://api.hamibot.com",
+    ]);
 
-/**
- * @description: 向 hamibot 服务器发送 GET 请求。
- * @param {string} path 请求的路径。
- * @param {RawAxiosRequestHeaders} [headers] 额外的 HTTP 请求头。
- * @return {Promise<DataType>} 服务器返回的数据。
- */
-export async function get<DataType extends object>(
-    path: string,
-    headers?: RawAxiosRequestHeaders
-): Promise<DataType> {
-    return requests<DataType>({
-        url: path,
-        method: "GET",
-        headers: await getHeaders(headers),
-    });
-}
+    /**
+     * @description: 获取 headers 中的重要信息，包括：
+     *
+     * - `Authorization`
+     * - `Content-Type`
+     * - `User-Agent`
+     *
+     * @return {object} 包含信息的对象。
+     */
+    private static getHeaders(): object {
+        const { packageJSON } = extensions.getExtension(
+            "batu1579.hamibot-assistant"
+        )!;
+        const token = workspace
+            .getConfiguration("hamibot-assistant")
+            .get<string>("token");
 
-/**
- * @description: 向 hamibot 服务器发送 POST 请求。
- * @param {string} path 请求的路径。
- * @param {object} data 请求附带的数据。
- * @param {RawAxiosRequestHeaders} [headers] 额外的 HTTP 请求头。
- * @return {Promise<DataType>} 服务器返回的数据。
- */
-export async function post<DataType extends object>(
-    path: string,
-    data: object,
-    headers?: RawAxiosRequestHeaders
-): Promise<DataType> {
-    return requests<DataType>({
-        url: path,
-        method: "POST",
-        data: data,
-        headers: await getHeaders(headers),
-    });
-}
-
-/**
- * @description: 向 hamibot 服务器发送 PUT 请求。
- * @param {string} path 请求的路径。
- * @param {object} data 请求附带的数据
- * @param {RawAxiosRequestHeaders} [headers] 额外的 HTTP 请求头。。
- * @return {Promise<DataType>} 服务器返回的数据。
- */
-export async function put<DataType extends object>(
-    path: string,
-    data?: object,
-    headers?: RawAxiosRequestHeaders
-): Promise<DataType> {
-    return requests<DataType>({
-        url: path,
-        method: "PUT",
-        data: data,
-        headers: await getHeaders(headers),
-    });
-}
-
-/**
- * @description: 向 hamibot 服务器发送 DELETE 请求。
- * @param {string} path 请求的路径。
- * @param {RawAxiosRequestHeaders} [headers] 额外的 HTTP 请求头。
- * @return {Promise<DataType>} 服务器返回的数据。
- */
-export async function del<DataType extends object>(
-    path: string,
-    data?: object,
-    headers?: RawAxiosRequestHeaders
-): Promise<DataType> {
-    return requests<DataType>({
-        url: path,
-        method: "DELETE",
-        data: data,
-        headers: await getHeaders(headers),
-    });
-}
-
-/**
- * @description: 向 hamibot 服务器发送请求。
- * @param {AxiosRequestConfig} config 请求配置。
- * @return {Promise<DataType>} 发送后服务器返回的数据。
- */
-async function requests<DataType>(
-    config: AxiosRequestConfig
-): Promise<DataType> {
-    if (!config.baseURL) {
-        config.baseURL = BASE_URL;
+        return {
+            /* eslint-disable */
+            Authorization: `token ${validToken(token)}`,
+            "Content-Type": "application/json",
+            "User-Agent": `hamibot-assistant ${packageJSON.version}`,
+            /* eslint-enable */
+        };
     }
 
-    return axios
-        .request<DataType>(config)
-        .then((response) => response.data)
-        .catch((error: any) => {
-            if (!isAxiosError(error)) {
+    /**
+     * @description: 处理请求中出现的异常，给出更精确的错误描述
+     * @param {AxiosError} error 捕获到的请求异常对象
+     */
+    private static handleRequestError(error: AxiosError): never {
+        if (!error.response) {
+            throw new Error("未收到响应数据，请稍后重试");
+        }
+
+        const { status } = error.response;
+
+        if (status >= 500) {
+            throw new Error("服务器异常，请向 Hamibot 官方反馈！");
+        }
+
+        switch (status) {
+            case 401:
+                // Token 有误
+                commands.executeCommand("hamibot-assistant.setApiToken");
+                throw new Error("开发者令牌无效，请重新设置！");
+
+            case 422:
+                // 参数有误
+                throw new Error("请求参数格式有误，请检查！");
+
+            case 429:
+                // 频率限制
+                throw new Error("本月 API 调用次数已达上限！");
+        }
+
+        throw new Error(
+            `未知错误码，请在仓库提交 issue 。详细信息：${error.message}`
+        );
+    }
+
+    /**
+     * @description: 向 hamibot 服务器发送请求。
+     * @param {AxiosRequestConfig} config 请求配置。
+     * @return {Promise<DataType>} 发送后服务器返回的数据。
+     */
+    private static async sendRequest<DataType>(
+        config: AxiosRequestConfig
+    ): Promise<DataType> {
+        config.headers = { ...config.headers, ...this.getHeaders() };
+        const requests = [...this.baseUrls].map((_url) =>
+            axios.request<DataType>(config)
+        );
+
+        try {
+            return (await Promise.race(requests)).data;
+        } catch (error: any) {
+            if (isAxiosError(error)) {
+                this.handleRequestError(error);
+            } else {
                 throw new Error(
                     `未知异常，请在仓库提交 issue 。详细信息：${error.message}`
                 );
             }
+        }
+    }
 
-            if (!error.response) {
-                throw new Error("未收到响应数据，请稍后重试");
-            }
-
-            let state = error.response.status;
-
-            if (state >= 500) {
-                if (config.baseURL === BASE_URL) {
-                    // 如果是服务器异常尝试访问备用域名
-                    config.baseURL = BACKUP_URL;
-                    return requests(config);
-                } else {
-                    throw new Error("服务器异常，请向 Hamibot 官方反馈！");
-                }
-            }
-
-            switch (state) {
-                case 401:
-                    // Token 有误
-                    commands.executeCommand("hamibot-assistant.setApiToken");
-                    throw new Error("开发者令牌无效，请重新设置！");
-
-                case 422:
-                    // 参数有误
-                    throw new Error("请求参数格式有误，请检查！");
-
-                case 429:
-                    // 频率限制
-                    throw new Error("本月 API 调用次数已达上限！");
-            }
-
-            throw new Error(
-                `未知异常，请在仓库提交 issue 。详细信息：${error.message}`
-            );
+    /**
+     * @description: 向 hamibot 服务器发送 GET 请求。
+     * @param {string} path 请求的路径。
+     * @param {AxiosHeaders} [headers] 额外的 HTTP 请求头。
+     * @return {Promise<DataType>} 服务器返回的数据。
+     */
+    public static async get<DataType extends object>(
+        path: string
+    ): Promise<DataType> {
+        return this.sendRequest<DataType>({
+            url: path,
+            method: "GET",
         });
-}
+    }
 
-/**
- * @description: 构造请求 headers ，统一添加开发者令牌。
- * @param {RawAxiosRequestHeaders} headers 额外的 headers 设置。
- * @return {RawAxiosRequestHeaders} 构造好的 headers 。
- */
-async function getHeaders(
-    headers?: RawAxiosRequestHeaders
-): Promise<RawAxiosRequestHeaders> {
-    let version = extensions.getExtension("batu1579.hamibot-assistant")
-        ?.packageJSON?.version;
-    let token = validToken(
-        await workspace.getConfiguration("hamibot-assistant").get("apiToken")
-    );
+    /**
+     * @description: 向 hamibot 服务器发送 POST 请求。
+     * @param {string} path 请求的路径。
+     * @param {object} data 请求附带的数据。
+     * @return {Promise<DataType>} 服务器返回的数据。
+     */
+    public static async post<DataType extends object>(
+        path: string,
+        data: object
+    ): Promise<DataType> {
+        return this.sendRequest<DataType>({
+            url: path,
+            method: "POST",
+            data: data,
+        });
+    }
 
-    return {
-        /* eslint-disable */
-        "User-Agent": `hamibot-assistant ${version}`,
-        Authorization: `token ${token}`,
-        "Content-Type": "application/json",
-        /* eslint-enable */
-        ...headers,
-    };
+    /**
+     * @description: 向 hamibot 服务器发送 PUT 请求。
+     * @param {string} path 请求的路径。
+     * @param {object} data 请求附带的数据
+     * @return {Promise<DataType>} 服务器返回的数据。
+     */
+    public static async put<DataType extends object>(
+        path: string,
+        data?: object
+    ): Promise<DataType> {
+        return this.sendRequest<DataType>({
+            url: path,
+            method: "PUT",
+            data: data,
+        });
+    }
+
+    /**
+     * @description: 向 hamibot 服务器发送 DELETE 请求。
+     * @param {string} path 请求的路径。
+     * @param {object} data 请求附带的数据。
+     * @return {Promise<DataType>} 服务器返回的数据。
+     */
+    public static async del<DataType extends object>(
+        path: string,
+        data?: object
+    ): Promise<DataType> {
+        return this.sendRequest<DataType>({
+            url: path,
+            method: "DELETE",
+            data: data,
+        });
+    }
 }


### PR DESCRIPTION
将原本的 request 模块重构为一个工具类，让逻辑更清晰。同时添加了几项改进：

- 提高了重试的速度，现在会同时使用给出的所有 baseURL 进行请求。
- 修改 baseURL 为一个集合，方便以后添加和删除。