### PR TITLE
Fix error when open config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复创建项目会出现 Unexpected end of JSON input 的问题 [#21](https://github.com/batu1579/hamibot-assistant/issues/21)
+
 ### Security
 
 - Axios 旧版本有漏洞，更新版本到 1.6.5

--- a/src/command/command.ts
+++ b/src/command/command.ts
@@ -147,6 +147,8 @@ async function commandsHandler(
                     try {
                         await checkRequirements(command.requirements);
                     } catch (error) {
+                        console.error("error", error);
+
                         if (!isNativeError(error)) {
                             throw error;
                         }
@@ -224,6 +226,8 @@ async function exceptionHandler(
             await INFO_DIALOG.showDialog(context, c.doneInfo);
         }
     } catch (error) {
+        console.error(error);
+
         if (!isNativeError(error)) {
             throw error;
         }

--- a/src/command/command.ts
+++ b/src/command/command.ts
@@ -1,10 +1,4 @@
-import {
-    Uri,
-    window,
-    commands,
-    workspace,
-    ExtensionContext
-} from "vscode";
+import { Uri, window, commands, workspace, ExtensionContext } from "vscode";
 import { isNativeError } from "util/types";
 
 import { HamibotConfig } from "../lib/projectConfig";
@@ -14,43 +8,44 @@ import {
     stopScript,
     initProject,
     uploadScript,
-    uploadAndRunScript
+    uploadAndRunScript,
 } from "./operation";
 
 import {
     setApiToken,
     setShowOfflineRobot,
     setDefaultExecuteRobot,
-    setProjectTemplate
+    setProjectTemplate,
 } from "./globalConfig";
 
 import {
     setProjectName,
     markConfigFile,
     markScriptFile,
-    setExecuteRobot
+    setExecuteRobot,
 } from "./projectConfig";
 
-export async function registerCommand(context: ExtensionContext): Promise<void> {
-    await commandsHandler(context,
+export async function registerCommand(
+    context: ExtensionContext
+): Promise<void> {
+    await commandsHandler(
+        context,
         // 全局设置
         {
             id: "hamibot-assistant.setApiToken",
             commandFunc: setApiToken,
-            doneInfo: "开发者令牌已更新"
+            doneInfo: "开发者令牌已更新",
         },
         {
             id: "hamibot-assistant.setShowOfflineRobot",
             commandFunc: setShowOfflineRobot,
-            doneInfo: "机器人显示设置已更新"
+            doneInfo: "机器人显示设置已更新",
         },
         {
             id: "hamibot-assistant.setDefaultExecuteRobot",
             commandFunc: setDefaultExecuteRobot,
             doneInfo: "默认调试机器人已更新",
-            requirements: [
-                NEED_API_TOKEN,
-            ]
+            requirements: [NEED_API_TOKEN],
         },
         {
             id: "hamibot-assistant.resetDialogs",
@@ -60,12 +55,12 @@ export async function registerCommand(context: ExtensionContext): Promise<void> 
                 }
                 return Job.done;
             },
-            doneInfo: "提示信息已重置"
+            doneInfo: "提示信息已重置",
         },
         {
             id: "hamibot-assistant.setProjectTemplate",
             commandFunc: setProjectTemplate,
-            doneInfo: "模板设置已更新"
+            doneInfo: "模板设置已更新",
         },
 
         // 项目设置
@@ -75,26 +70,24 @@ export async function registerCommand(context: ExtensionContext): Promise<void> 
             doneInfo: "项目名称已更新",
             requirements: [
                 NEED_API_TOKEN,
-                new ProjectConfigRequirement('scriptId')
-            ]
+                new ProjectConfigRequirement("scriptId"),
+            ],
         },
         {
             id: "hamibot-assistant.markScriptFile",
             commandFunc: markScriptFile,
-            doneInfo: "脚本文件标记已更新"
+            doneInfo: "脚本文件标记已更新",
         },
         {
             id: "hamibot-assistant.markConfigFile",
             commandFunc: markConfigFile,
-            doneInfo: "配置文件标记已更新"
+            doneInfo: "配置文件标记已更新",
         },
         {
             id: "hamibot-assistant.setExecuteRobot",
             commandFunc: setExecuteRobot,
             doneInfo: "调试机器人已更新",
-            requirements: [
-                NEED_API_TOKEN,
-            ]
+            requirements: [NEED_API_TOKEN],
         },
 
         // 操作
@@ -102,9 +95,7 @@ export async function registerCommand(context: ExtensionContext): Promise<void> 
             id: "hamibot-assistant.initProject",
             commandFunc: initProject,
             doneInfo: "新项目已创建",
-            requirements: [
-                NEED_API_TOKEN,
-            ]
+            requirements: [NEED_API_TOKEN],
         },
         {
             id: "hamibot-assistant.uploadScript",
@@ -112,9 +103,9 @@ export async function registerCommand(context: ExtensionContext): Promise<void> 
             doneInfo: "脚本文件已上传",
             requirements: [
                 NEED_API_TOKEN,
-                new ProjectConfigRequirement('scriptId'),
-                new ProjectConfigRequirement('fileMark')
-            ]
+                new ProjectConfigRequirement("scriptId"),
+                new ProjectConfigRequirement("fileMark"),
+            ],
         },
         {
             id: "hamibot-assistant.uploadAndRunScript",
@@ -122,9 +113,9 @@ export async function registerCommand(context: ExtensionContext): Promise<void> 
             doneInfo: "开始运行脚本",
             requirements: [
                 NEED_API_TOKEN,
-                new ProjectConfigRequirement('scriptId'),
-                new ProjectConfigRequirement('fileMark')
-            ]
+                new ProjectConfigRequirement("scriptId"),
+                new ProjectConfigRequirement("fileMark"),
+            ],
         },
         {
             id: "hamibot-assistant.stopScript",
@@ -132,9 +123,9 @@ export async function registerCommand(context: ExtensionContext): Promise<void> 
             doneInfo: "脚本已停止运行",
             requirements: [
                 NEED_API_TOKEN,
-                new ProjectConfigRequirement('scriptId'),
-                new ProjectConfigRequirement('executeRobot')
-            ]
+                new ProjectConfigRequirement("scriptId"),
+                new ProjectConfigRequirement("executeRobot"),
+            ],
         }
     );
 }
@@ -144,7 +135,10 @@ export async function registerCommand(context: ExtensionContext): Promise<void> 
  * @param {ExtensionContext} context 扩展上下文。
  * @param {Command} commandList 要包装的指令对象。
  */
-async function commandsHandler(context: ExtensionContext, ...commandList: Command[]): Promise<void> {
+async function commandsHandler(
+    context: ExtensionContext,
+    ...commandList: Command[]
+): Promise<void> {
     for (const command of commandList) {
         context.subscriptions.push(
             commands.registerCommand(command.id, async (uri: Uri) => {
@@ -165,7 +159,7 @@ async function commandsHandler(context: ExtensionContext, ...commandList: Comman
 
                 // 重试循环
                 while (await exceptionHandler(context, uri, command)) {
-                    window.showInformationMessage('正在重试...');
+                    window.showInformationMessage("正在重试...");
                 }
             })
         );
@@ -180,14 +174,15 @@ async function checkRequirements(requirements: RequireInfo[]): Promise<void> {
         switch (req.type) {
             case RequireType.vscodeConfig:
                 config = await workspace
-                    .getConfiguration('hamibot-assistant')
+                    .getConfiguration("hamibot-assistant")
                     .get(req.field);
                 break;
 
             case RequireType.projectConfig:
                 // 延迟到有需要的时候读取
                 if (!projectConfig) {
-                    projectConfig = await global.currentConfig.getProjectConfig();
+                    projectConfig =
+                        await global.currentConfig.getProjectConfig();
                 }
                 config = await HamibotConfig.getConfigByFieldName(
                     projectConfig,
@@ -215,7 +210,11 @@ async function checkRequirements(requirements: RequireInfo[]): Promise<void> {
  * @param {Command} c 在指令对应的函数外添加异常处理。
  * @return {Promise<boolean>} 是否需要重试。
  */
-async function exceptionHandler(context: ExtensionContext, uri: Uri, c: Command): Promise<boolean> {
+async function exceptionHandler(
+    context: ExtensionContext,
+    uri: Uri,
+    c: Command
+): Promise<boolean> {
     let needRetry = false;
 
     try {
@@ -230,7 +229,7 @@ async function exceptionHandler(context: ExtensionContext, uri: Uri, c: Command)
         }
 
         needRetry = await ERROR_DIALOG.showDialog(context, error.message);
-    };
+    }
 
     return needRetry;
 }
@@ -254,13 +253,13 @@ interface Command {
     /**
      * @description: 指令依赖的信息
      */
-    requirements?: RequireInfo[]
+    requirements?: RequireInfo[];
 }
 
 export enum Job {
     done,
-    undone
-};
+    undone,
+}
 
 interface RequireInfo {
     /**
@@ -281,7 +280,7 @@ interface RequireInfo {
 
 enum RequireType {
     vscodeConfig,
-    projectConfig
+    projectConfig,
 }
 
 abstract class ConfigRequirement implements RequireInfo {
@@ -295,25 +294,30 @@ abstract class ConfigRequirement implements RequireInfo {
         this.onNotSatisfied = onNotSatisfied ?? this.defaultCallback;
     }
 
-    protected async defaultCallback(): Promise<void> { }
+    protected async defaultCallback(): Promise<void> {}
 }
 
 class VSCodeConfigRequirement extends ConfigRequirement implements RequireInfo {
     type: RequireType = RequireType.vscodeConfig;
 
     protected async defaultCallback(): Promise<void> {
-        await commands.executeCommand('workbench.action.openSettingsJson');
-    };
+        await commands.executeCommand("workbench.action.openSettingsJson");
+    }
 }
 
-class ProjectConfigRequirement extends ConfigRequirement implements RequireInfo {
+class ProjectConfigRequirement
+    extends ConfigRequirement
+    implements RequireInfo
+{
     type: RequireType = RequireType.projectConfig;
 
     protected async defaultCallback(): Promise<void> {
-        await window.showTextDocument(global.currentConfig.getProjectConfigFileUri());
-    };
+        await window.showTextDocument(
+            global.currentConfig.getProjectConfigFileUri()
+        );
+    }
 }
 
 const NEED_API_TOKEN = new VSCodeConfigRequirement("apiToken", () => {
-    commands.executeCommand('hamibot-assistant.setApiToken');
+    commands.executeCommand("hamibot-assistant.setApiToken");
 });

--- a/src/lib/projectConfig.ts
+++ b/src/lib/projectConfig.ts
@@ -2,41 +2,47 @@ import { existsSync } from "fs";
 import { workspace, Uri } from "vscode";
 
 interface ProjectConfig {
-    readonly name?: string,
-    readonly scriptId?: string,
-    readonly executeRobot?: RobotInfo,
-    readonly fileMark?: FileMarks
+    readonly name?: string;
+    readonly scriptId?: string;
+    readonly executeRobot?: RobotInfo;
+    readonly fileMark?: FileMarks;
 }
 
 export interface RobotInfo {
-    _id?: string,
-    name?: string
+    _id?: string;
+    name?: string;
 }
 
 interface FileMarks {
-    configFile?: string,
-    scriptFile?: string
+    configFile?: string;
+    scriptFile?: string;
 }
 
 export class HamibotConfig {
     private workspaceUri: Uri | undefined;
-    private static readonly configFileName = 'hamibot.config.json';
+    private static readonly configFileName = "hamibot.config.json";
     private static readonly defaultConfig = {};
 
     private constructor(workspaceUri?: Uri) {
-        this.workspaceUri = workspaceUri ?? HamibotConfig.getCurrentWorkspaceUri();
+        this.workspaceUri =
+            workspaceUri ?? HamibotConfig.getCurrentWorkspaceUri();
     }
 
     public static initConfig(workspaceUri?: Uri): HamibotConfig {
         return new HamibotConfig(workspaceUri);
     }
 
-    public static async newConfigFile(workspaceUri?: Uri, config?: ProjectConfig): Promise<HamibotConfig> {
+    public static async newConfigFile(
+        workspaceUri?: Uri,
+        config?: ProjectConfig
+    ): Promise<HamibotConfig> {
         let configObject = new HamibotConfig(workspaceUri);
 
         if (configObject.workspaceUri) {
             // 检查是否存在配置文件（不存在则创建）
-            await configObject.checkConfigFile(config ?? HamibotConfig.defaultConfig);
+            await configObject.checkConfigFile(
+                config ?? HamibotConfig.defaultConfig
+            );
         }
 
         return configObject;
@@ -51,13 +57,16 @@ export class HamibotConfig {
 
     public getWorkspaceUri(): Uri {
         if (!this.workspaceUri) {
-            throw new Error('未找到打开的工作区或文件夹');
+            throw new Error("未找到打开的工作区或文件夹");
         }
         return this.workspaceUri;
     }
 
     public getProjectConfigFileUri(): Uri {
-        return Uri.joinPath(this.getWorkspaceUri(), HamibotConfig.configFileName);
+        return Uri.joinPath(
+            this.getWorkspaceUri(),
+            HamibotConfig.configFileName
+        );
     }
 
     /**
@@ -79,11 +88,19 @@ export class HamibotConfig {
      * HamibotConfig.getConfigByFieldName(config, "fileMark.configFile")
      * ```
      */
-    public static getConfigByFieldName(config: object, fieldPath: string | string[], defaultValue?: any): unknown {
-        let path = Array.isArray(fieldPath) ? fieldPath : fieldPath.replace(/\[(.*?)\]/g, '.$1').split('.');
-        return path.reduce((obj: object, key: string) => {
-            return Object.getOwnPropertyDescriptor(obj ?? {}, key)?.value;
-        }, config) ?? defaultValue;
+    public static getConfigByFieldName(
+        config: object,
+        fieldPath: string | string[],
+        defaultValue?: any
+    ): unknown {
+        if (!Array.isArray(fieldPath)) {
+            fieldPath = fieldPath.replace(/\[(.*?)\]/g, ".$1").split(".");
+        }
+        return (
+            fieldPath.reduce((obj: object, key: string) => {
+                return Object.getOwnPropertyDescriptor(obj ?? {}, key)?.value;
+            }, config) ?? defaultValue
+        );
     }
 
     /**

--- a/src/lib/projectConfig.ts
+++ b/src/lib/projectConfig.ts
@@ -116,10 +116,18 @@ export class HamibotConfig {
      * @param {ProjectConfig} newConfig 新的设置项。
      * @param {ProjectConfig} oldConfig 原有的设置项，主要用来避免频繁读取配置文件。但是如果读取时间和使用时间相隔很久，则建议直接从文件中重新读取，防止期间手动修改过配置文件。
      */
-    public async updateProjectConfig(newConfig: ProjectConfig, oldConfig: ProjectConfig): Promise<void>;
-    public async updateProjectConfig(newConfig: ProjectConfig, oldConfig?: ProjectConfig): Promise<void> {
-        oldConfig = oldConfig ?? await this.getProjectConfig();
-        this.writeProjectConfig(HamibotConfig.mergeConfig(oldConfig, newConfig));
+    public async updateProjectConfig(
+        newConfig: ProjectConfig,
+        oldConfig: ProjectConfig
+    ): Promise<void>;
+    public async updateProjectConfig(
+        newConfig: ProjectConfig,
+        oldConfig?: ProjectConfig
+    ): Promise<void> {
+        oldConfig = oldConfig ?? (await this.getProjectConfig());
+        return this.writeProjectConfig(
+            HamibotConfig.mergeConfig(oldConfig, newConfig)
+        );
     }
 
     /**
@@ -136,7 +144,7 @@ export class HamibotConfig {
      * @param {ProjectConfig} config 项目设置对象。
      */
     private async writeProjectConfig(config: ProjectConfig): Promise<void> {
-        await workspace.fs.writeFile(
+        return workspace.fs.writeFile(
             this.getProjectConfigFileUri(),
             Buffer.from(JSON.stringify(config, null, 4))
         );
@@ -149,7 +157,7 @@ export class HamibotConfig {
         }
 
         // 存入要更新的内容
-        await this.updateProjectConfig(config);
+        return this.updateProjectConfig(config);
     }
 
     /**

--- a/src/lib/projectConfig.ts
+++ b/src/lib/projectConfig.ts
@@ -74,7 +74,10 @@ export class HamibotConfig {
      * @return {Promise<ProjectConfig>} 项目设置对象。
      */
     public async getProjectConfig(): Promise<ProjectConfig> {
-        return this.readProjectConfig();
+        let configDocument = await workspace.fs.readFile(
+            this.getProjectConfigFileUri()
+        );
+        return JSON.parse(configDocument.toString());
     }
 
     /**
@@ -126,17 +129,6 @@ export class HamibotConfig {
     private static getCurrentWorkspaceUri(): Uri | undefined {
         const workspaceFolders = workspace.workspaceFolders;
         return workspaceFolders ? workspaceFolders[0].uri : undefined;
-    }
-
-    /**
-     * @description: 从配置文件中读取项目设置。
-     * @return {Promise<ProjectConfig>} 项目设置对象。
-     */
-    private async readProjectConfig(): Promise<ProjectConfig> {
-        let configDocument = await workspace.fs.readFile(
-            this.getProjectConfigFileUri()
-        );
-        return JSON.parse(configDocument.toString());
     }
 
     /**


### PR DESCRIPTION
原本的问题是因为在读取配置前尚未完成写入，导致最后解析的是一个空的字符串，所以会出现 JSON 解析异常。

现在返回为一个 Promise 对象，可以在外部被等待。理论上应该能修复这个问题。

#21 